### PR TITLE
Bypass RATLS for vmcall-raw test. Add comprehensive INFO logging for migration session progress

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@ cargo image --no-default-features --features vmcall-raw,stack-guard,main,test_di
 
 To build MigTD as a standard Rust app that can run in Azure TDX CVM environment, for development and testing purpose:
 ```
-cargo build --no-default-features --features AzCVMEmu
+cargo image --no-default-features --features vmcall-raw,stack-guard,main,test_disable_ra_and_accept_all --log-level info --image-format igvm --fw-top 0x3000000
 ```
 The detailed AzCVMEmu mode instructions can be found in `doc/AzCVMEmu.md`.
 

--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@ cargo image --no-default-features --features vmcall-raw,stack-guard,main,test_di
 
 To build MigTD as a standard Rust app that can run in Azure TDX CVM environment, for development and testing purpose:
 ```
-cargo image --no-default-features --features vmcall-raw,stack-guard,main,test_disable_ra_and_accept_all --log-level info --image-format igvm --fw-top 0x3000000
+cargo build --no-default-features --features AzCVMEmu
 ```
 The detailed AzCVMEmu mode instructions can be found in `doc/AzCVMEmu.md`.
 


### PR DESCRIPTION
Copy from https://github.com/intel/MigTD/commit/4e0b6d5b6cbbf970b8cadc7017b5bafdd2f14cb3#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15


- Added detailed logging in wait_for_request() to track migration request reception
- Enhanced exchange_msk() with vmcall-raw transport logging:
  * Connection establishment and closure
  * Source/destination role identification with Src/Dst prefixes
  * Exchange information send/receive operations
  * Migration version negotiation
- Added TLS transport path logging for completeness
- Enhanced MSK operations with read/write progress logging
- Updated readme.md with correct IGVM build commands including --fw-top parameter

These changes provide comprehensive execution progress tracking for debugging and monitoring migration operations in TDX environments.