### PR TITLE
Merge GHCI 1.5 fix

### DIFF
--- a/src/devices/vmcall_raw/src/transport/vmcall.rs
+++ b/src/devices/vmcall_raw/src/transport/vmcall.rs
@@ -28,7 +28,7 @@ lazy_static! {
     pub static ref VMCALL_MIG_CONTEXT_FLAGS: Mutex<BTreeMap<u64, AtomicBool>> =
         Mutex::new(BTreeMap::new());
 }
-const TDX_VMCALL_VMM_SUCCESS: u32 = 1;
+const TDX_VMCALL_VMM_SUCCESS: u8 = 1;
 
 fn push_stream_queues(stream: &VmcallRaw, buf: Vec<u8>) {
     if buf.is_empty() {
@@ -77,19 +77,19 @@ pub async fn vmcall_raw_transport_enqueue(
     stream: &VmcallRaw,
     buf: &[u8],
 ) -> Result<usize, VmcallRawError> {
-    let data_status: u32 = 0;
+    let data_status: u64 = 0;
     let data_length: u32 = buf.len() as u32;
 
-    let data_buffer_size = 4 + 4 + buf.len();
+    let data_buffer_size = 8 + 4 + buf.len();
     let data_buffer_page_count = align_up(data_buffer_size) / PAGE_SIZE;
     let mut data_buffer =
         SharedMemory::new(data_buffer_page_count).ok_or(VmcallRawError::Illegal)?;
 
     let data_buffer = data_buffer.as_mut_bytes();
 
-    data_buffer[0..4].copy_from_slice(&u32::to_le_bytes(data_status));
-    data_buffer[4..8].copy_from_slice(&u32::to_le_bytes(data_length));
-    data_buffer[8..(8 + buf.len())].copy_from_slice(buf);
+    data_buffer[0..8].copy_from_slice(&u64::to_le_bytes(data_status));
+    data_buffer[8..12].copy_from_slice(&u32::to_le_bytes(data_length));
+    data_buffer[12..(12 + buf.len())].copy_from_slice(buf);
     let truncated_buf = &mut data_buffer[..data_buffer_size];
 
     vmcall_service_migtd_send(stream.addr.transport_context(), truncated_buf).await
@@ -136,8 +136,9 @@ async fn vmcall_service_migtd_send(
         }
 
         let (_send_buf, data_status, data_length) = process_buffer(data_buffer);
+        let data_status_bytes = data_status.to_le_bytes();
 
-        if data_status != TDX_VMCALL_VMM_SUCCESS {
+        if data_status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
             return Poll::Pending;
         }
 
@@ -146,13 +147,13 @@ async fn vmcall_service_migtd_send(
     .await
 }
 
-fn process_buffer(buffer: &mut [u8]) -> (&mut [u8], u32, u32) {
-    assert!(buffer.len() >= 8, "Buffer too small!");
+fn process_buffer(buffer: &mut [u8]) -> (&mut [u8], u64, u32) {
+    assert!(buffer.len() >= 12, "Buffer too small!");
 
-    let (header, payload_buffer) = buffer.split_at_mut(8); // Split at 8th byte
+    let (header, payload_buffer) = buffer.split_at_mut(12); // Split at 12th byte
 
-    let data_status = u32::from_le_bytes(header[0..4].try_into().unwrap()); // First 4 bytes
-    let data_length = u32::from_le_bytes(header[4..8].try_into().unwrap()); // Next 4 bytes
+    let data_status = u64::from_le_bytes(header[0..8].try_into().unwrap()); // First 8 bytes
+    let data_length = u32::from_le_bytes(header[8..12].try_into().unwrap()); // Next 4 bytes
 
     (payload_buffer, data_status, data_length)
 }
@@ -177,8 +178,9 @@ async fn vmcall_service_migtd_receive(
         }
 
         let (response_buf, data_status, data_length) = process_buffer(data_buffer);
+        let data_status_bytes = data_status.to_le_bytes();
 
-        if data_status != TDX_VMCALL_VMM_SUCCESS {
+        if data_status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
             return Poll::Pending;
         }
 

--- a/src/migtd/src/lib.rs
+++ b/src/migtd/src/lib.rs
@@ -62,8 +62,8 @@ pub extern "C" fn _start(hob: u64, payload: u64) -> ! {
     // Run the global constructors
     init(payload);
 
-    // // Initilize the APIC timer
-    // driver::timer::init_timer();
+    // Initilize the APIC timer
+    driver::timer::init_timer();
 
     #[cfg(feature = "virtio-serial")]
     driver::serial::virtio_serial_device_init();
@@ -80,8 +80,8 @@ pub extern "C" fn _start(hob: u64, payload: u64) -> ! {
     #[cfg(feature = "vmcall-raw")]
     driver::vmcall_raw::vmcall_raw_device_init();
 
-    // // Initilize the system ticks
-    // driver::ticks::init_sys_tick();
+    // Initilize the system ticks
+    driver::ticks::init_sys_tick();
 
     arch::init::init(&layout, main);
 }


### PR DESCRIPTION
This commit integrates GHCI 1.5 fix
with Microsoft's internal testing branch, providing comprehensive migration testing capabilities.

Key Changes:
* vmcall_raw mode GHCI 1.5 fix from https://github.com/mjjagasi/MigTD/tree/MTC_GHCI_PoCv2

* re-enabled timer and tick initalization, with OneShot APIC timer now supported

* Change test_accept_all mode RATLS bypass code to be fully under test_accept_all feature gate. If test_accept_all feature is not defined, no behavior difference with regard to RATLS

* Testing Infrastructure:
  - Added --test-accept-all and --test-reject-all options to migtdemu.sh
  - Optimized test_reject_all implementation for minimal async overhead
  - Enhanced AzCVMEmu support for test_reject_all feature
  - Improved build script with flexible feature combinations