### PR TITLE
Revert "spdm: add test_disable_ra_and_accept_all feature gate for quo…

### DIFF
--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -407,11 +407,8 @@ pub async fn send_and_receive_sdm_migration_attest_info(
     //quote src
     let quote_src = gen_quote_spdm(&report_data[..report_data_prefix_len + th1_len])
         .map_err(|_| SPDM_STATUS_INVALID_STATE_LOCAL)?;
-
-    #[cfg(not(feature = "test_disable_ra_and_accept_all"))]
     let res = attestation::verify_quote(quote_src.as_slice());
     //  The session MUST be terminated immediately, if the mutual attestation failure
-    #[cfg(not(feature = "test_disable_ra_and_accept_all"))]
     if res.is_err() {
         error!("mutual attestation failed, end the session!\n");
         let session = spdm_requester
@@ -421,10 +418,7 @@ pub async fn send_and_receive_sdm_migration_attest_info(
         session.teardown();
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
     }
-    #[cfg(all(
-        not(feature = "test_disable_ra_and_accept_all"),
-        not(feature = "policy_v2")
-    ))]
+    #[cfg(not(feature = "policy_v2"))]
     let verified_report_local = res.unwrap();
 
     let quote_element = VdmMessageElement {
@@ -524,10 +518,7 @@ pub async fn send_and_receive_sdm_migration_attest_info(
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
     }
     let quote_dst = reader.take(vdm_element.length as usize).unwrap();
-
-    #[cfg(not(feature = "test_disable_ra_and_accept_all"))]
     let res = attestation::verify_quote(quote_dst);
-    #[cfg(not(feature = "test_disable_ra_and_accept_all"))]
     if res.is_err() {
         error!("mutual attestation failed, end the session!\n");
         let session = spdm_requester
@@ -537,10 +528,7 @@ pub async fn send_and_receive_sdm_migration_attest_info(
         session.teardown();
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
     }
-    #[cfg(all(
-        not(feature = "test_disable_ra_and_accept_all"),
-        not(feature = "policy_v2")
-    ))]
+    #[cfg(not(feature = "policy_v2"))]
     let verified_report_peer = res.unwrap();
 
     //event log dst
@@ -557,10 +545,7 @@ pub async fn send_and_receive_sdm_migration_attest_info(
     #[cfg(feature = "policy_v2")]
     let _event_log_dst = reader.take(vdm_element.length as usize).unwrap();
 
-    #[cfg(all(
-        not(feature = "test_disable_ra_and_accept_all"),
-        not(feature = "policy_v2")
-    ))]
+    #[cfg(not(feature = "policy_v2"))]
     {
         let policy_check_result = mig_policy::authenticate_policy(
             true,

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -317,10 +317,8 @@ pub fn handle_exchange_mig_attest_info_req(
     let quote_dst = gen_quote_spdm(&report_data[..report_data_prefix_len + th1_len])
         .map_err(|_| SPDM_STATUS_INVALID_STATE_LOCAL)?;
 
-    #[cfg(not(feature = "test_disable_ra_and_accept_all"))]
     let res = attestation::verify_quote(quote_dst.as_slice());
     //  The session MUST be terminated immediately, if the mutual attestation failure
-    #[cfg(not(feature = "test_disable_ra_and_accept_all"))]
     if res.is_err() {
         error!("mutual attestation failed, end the session!\n");
         let session = responder_context
@@ -330,10 +328,7 @@ pub fn handle_exchange_mig_attest_info_req(
         session.teardown();
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
     }
-    #[cfg(all(
-        not(feature = "test_disable_ra_and_accept_all"),
-        not(feature = "policy_v2")
-    ))]
+    #[cfg(not(feature = "policy_v2"))]
     let verified_report_local = res.unwrap();
 
     //quote src
@@ -346,11 +341,8 @@ pub fn handle_exchange_mig_attest_info_req(
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
     }
     let quote_src = reader.take(vdm_element.length as usize).unwrap();
-
-    #[cfg(not(feature = "test_disable_ra_and_accept_all"))]
     let res = attestation::verify_quote(quote_src);
     //  The session MUST be terminated immediately, if the mutual attestation failure
-    #[cfg(not(feature = "test_disable_ra_and_accept_all"))]
     if res.is_err() {
         error!("mutual attestation failed, end the session!\n");
         let session = responder_context
@@ -360,10 +352,7 @@ pub fn handle_exchange_mig_attest_info_req(
         session.teardown();
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
     }
-    #[cfg(all(
-        not(feature = "test_disable_ra_and_accept_all"),
-        not(feature = "policy_v2")
-    ))]
+    #[cfg(not(feature = "policy_v2"))]
     let verified_report_peer = res.unwrap();
 
     //event log src
@@ -380,10 +369,7 @@ pub fn handle_exchange_mig_attest_info_req(
     #[cfg(feature = "policy_v2")]
     let _event_log_src = reader.take(vdm_element.length as usize).unwrap();
 
-    #[cfg(all(
-        not(feature = "test_disable_ra_and_accept_all"),
-        not(feature = "policy_v2")
-    ))]
+    #[cfg(not(feature = "policy_v2"))]
     {
         let policy_check_result = mig_policy::authenticate_policy(
             false,


### PR DESCRIPTION
…te verification"

This reverts commit cdea5579d6140db9b28a6f7285099b268ba1e6ff. 

The spdm code in upstream intel/migtd is still evolving. The "test_disable_ra_and_accept_all" changes in previous commit makes it hard to sync with upstream.