### PR TITLE
Minimize upstream diffs using conditional extern crate pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "der",
  "spin 0.9.8",
  "td-payload",
+ "td-payload-emu",
  "tdx-tdcall",
  "tdx-tdcall-emu",
 ]
@@ -2195,6 +2196,7 @@ dependencies = [
  "lazy_static",
  "spin 0.9.8",
  "td-payload",
+ "td-shim-emu",
 ]
 
 [[package]]

--- a/deps/td-shim-AzCVMEmu/td-payload-emu/Cargo.toml
+++ b/deps/td-shim-AzCVMEmu/td-payload-emu/Cargo.toml
@@ -9,5 +9,6 @@ description = "AzCVMEmu shim for td-payload APIs used by vmcall_raw"
 # Re-export the real td-payload for most functionality
 td-payload-real = { path = "../../td-shim/td-payload", package = "td-payload", features = ["tdx"] }
 interrupt-emu = { path = "../interrupt-emu", package = "interrupt-emu" }
+td-shim-emu = { path = "../td-shim" }
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 spin = "0.9"

--- a/deps/td-shim-AzCVMEmu/td-payload-emu/src/acpi/mod.rs
+++ b/deps/td-shim-AzCVMEmu/td-payload-emu/src/acpi/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! ACPI emulation module for AzCVMEmu mode
+//!
+//! Re-exports ACPI functionality from td_shim_emu to match
+//! the same API as td_payload::acpi in non-emulation mode
+
+pub use td_shim_emu::event_log::get_acpi_tables;

--- a/deps/td-shim-AzCVMEmu/td-payload-emu/src/arch/apic/mod.rs
+++ b/deps/td-shim-AzCVMEmu/td-payload-emu/src/arch/apic/mod.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! APIC emulation stubs for AzCVMEmu mode
+//!
+//! In emulation mode, there's no real APIC hardware, so we provide
+//! stub implementations that are safe no-ops.
+
+/// Disable interrupts (no-op in emulation mode)
+pub fn disable() {
+    // No-op in emulation mode - no real APIC to disable
+}
+
+/// Enable interrupts and halt (yields CPU in emulation mode)
+pub fn enable_and_hlt() {
+    // In emulation mode, there's no real halt instruction
+    // Just yield the CPU with a spin loop hint
+    // The caller's loop will check the NOTIFIER flag and break when set
+    core::hint::spin_loop();
+}
+
+/// One-shot TSC deadline mode (no-op in emulation mode)
+pub fn one_shot_tsc_deadline_mode(_period: u64) -> Option<u64> {
+    // No-op in emulation mode - no real APIC timer
+    None
+}
+
+/// Reset one-shot TSC deadline mode (no-op in emulation mode)
+pub fn one_shot_tsc_deadline_mode_reset() {
+    // No-op in emulation mode
+}
+
+/// One-shot APIC timer mode (no-op in emulation mode)
+#[cfg(feature = "oneshot-apic")]
+pub fn one_shot(_ticks: u64) {
+    // No-op in emulation mode
+}
+
+/// Reset one-shot APIC timer (no-op in emulation mode)
+#[cfg(feature = "oneshot-apic")]
+pub fn one_shot_reset() {
+    // No-op in emulation mode
+}
+
+/// MSR LVTT register constant (for compatibility)
+pub const MSR_LVTT: u32 = 0x832;

--- a/deps/td-shim-AzCVMEmu/td-payload-emu/src/lib.rs
+++ b/deps/td-shim-AzCVMEmu/td-payload-emu/src/lib.rs
@@ -16,8 +16,11 @@ pub mod arch {
     // Re-export most arch functionality from real td-payload
     pub use td_payload_real::arch::*;
 
-    // Override only the IDT module for emulation
+    // Override the IDT module for emulation
     pub mod idt;
+
+    // Override the APIC module for emulation
+    pub mod apic;
 }
 
 pub mod mm {
@@ -27,3 +30,6 @@ pub mod mm {
     // Override only the shared module for emulation
     pub mod shared;
 }
+
+// Override the ACPI module for emulation
+pub mod acpi;

--- a/deps/td-shim-AzCVMEmu/td-shim-interface/src/lib.rs
+++ b/deps/td-shim-AzCVMEmu/td-shim-interface/src/lib.rs
@@ -35,6 +35,7 @@
 
 extern crate alloc;
 
+pub mod acpi;
 pub mod file_ops;
 pub mod td_uefi_pi;
 
@@ -46,6 +47,6 @@ pub use td_uefi_pi::fv::{
 #[cfg(feature = "policy_v2")]
 pub use td_uefi_pi::fv::load_policy_issuer_chain_from_file;
 
-pub use file_ops::init_file_based_emulation_with_real_files;
 #[cfg(feature = "policy_v2")]
 pub use file_ops::init_file_based_emulation_with_policy_chain;
+pub use file_ops::init_file_based_emulation_with_real_files;

--- a/deps/td-shim-AzCVMEmu/tdx-tdcall/src/lib.rs
+++ b/deps/td-shim-AzCVMEmu/tdx-tdcall/src/lib.rs
@@ -57,7 +57,7 @@ pub mod tdx {
         tdvmcall_mmio_write,
         tdvmcall_rdmsr,
         tdvmcall_service,
-        tdvmcall_setup_event_notify,
+        // tdvmcall_setup_event_notify is emulated, not re-exported
         tdvmcall_sti_halt,
         tdvmcall_wrmsr,
         // Re-export types
@@ -69,7 +69,7 @@ pub mod tdx {
         tdcall_extend_rtmr, tdcall_servtd_rd, tdcall_servtd_wr, tdcall_sys_rd, tdcall_sys_wr,
         tdvmcall_get_quote, tdvmcall_migtd_receive_sync as tdvmcall_migtd_receive,
         tdvmcall_migtd_reportstatus, tdvmcall_migtd_send_sync as tdvmcall_migtd_send,
-        tdvmcall_migtd_waitforrequest,
+        tdvmcall_migtd_waitforrequest, tdvmcall_setup_event_notify,
     };
 }
 
@@ -80,7 +80,9 @@ pub mod tdreport {
     use original_tdx_tdcall::TdCallError;
 
     // Re-export some useful constants and types from original
-    pub use original_tdx_tdcall::tdreport::{TdxReport, TD_REPORT_SIZE};
+    pub use original_tdx_tdcall::tdreport::{
+        TdxReport, TD_REPORT_ADDITIONAL_DATA_SIZE, TD_REPORT_SIZE,
+    };
 
     /// Emulated tdcall_report function for AzCVMEmu mode
     /// Now returns the exact same error type as the original for perfect compatibility

--- a/src/attestation/Cargo.toml
+++ b/src/attestation/Cargo.toml
@@ -12,12 +12,13 @@ spin = "0.9.2"
 tdx-tdcall = { path = "../../deps/td-shim/tdx-tdcall"}
 td-payload = { path = "../../deps/td-shim/td-payload", features = ["tdx"] }
 
-# Use emulated tdx-tdcall for AzCVMEmu
+# Use emulated versions for AzCVMEmu
 tdx-tdcall-emu = { path = "../../deps/td-shim-AzCVMEmu/tdx-tdcall", optional = true }
+td-payload-emu = { path = "../../deps/td-shim-AzCVMEmu/td-payload-emu", optional = true }
 
 [features]
 default = []
 test = []
-AzCVMEmu = ["tdx-tdcall-emu"]
+AzCVMEmu = ["tdx-tdcall-emu", "td-payload-emu"]
 attest-lib-ext = []
 policy_v2=[]

--- a/src/attestation/src/attest.rs
+++ b/src/attestation/src/attest.rs
@@ -12,14 +12,32 @@ use crate::{
 use alloc::{ffi::CString, vec, vec::Vec};
 use core::{alloc::Layout, ffi::c_void, ops::Range};
 
-#[cfg(not(feature = "AzCVMEmu"))]
-use crate::binding::get_quote as get_quote_inner;
-#[cfg(not(feature = "AzCVMEmu"))]
-use tdx_tdcall::tdreport::*;
+use crate::ghci::ghci_get_quote;
 
 const TD_QUOTE_SIZE: usize = 0x2000;
 const TD_REPORT_VERIFY_SIZE: usize = 1024;
 const ATTEST_HEAP_SIZE: usize = 0x80000;
+
+// TDX GHCI GetQuote status codes
+const GET_QUOTE_SUCCESS: u64 = 0x0;
+const GET_QUOTE_IN_FLIGHT: u64 = 0xFFFFFFFF_FFFFFFFF;
+const GET_QUOTE_ERROR: u64 = 0x80000000_00000000;
+const GET_QUOTE_SERVICE_UNAVAILABLE: u64 = 0x80000000_00000001;
+
+#[repr(C)]
+#[allow(dead_code)]
+struct ServtdTdxQuoteHdr {
+    /* Quote version, filled by TD */
+    version: u64,
+    /* Status code of Quote request, filled by VMM */
+    status: u64,
+    /* Length of TDREPORT, filled by TD */
+    in_len: u32,
+    /* Length of Quote, filled by VMM */
+    out_len: u32,
+    /* Actual Quote data or TDREPORT on input */
+    data: [u8; 0],
+}
 
 /// C-compatible version of Collateral with null-terminated strings
 #[derive(Debug)]
@@ -72,79 +90,54 @@ pub fn attest_init_heap() -> Option<usize> {
     Some(ATTEST_HEAP_SIZE)
 }
 
-#[cfg(not(feature = "AzCVMEmu"))]
-pub fn get_quote(td_report: &[u8]) -> Result<Vec<u8>, Error> {
-    let mut quote = vec![0u8; TD_QUOTE_SIZE];
-    let mut quote_size = TD_QUOTE_SIZE as u32;
-    unsafe {
-        let result = get_quote_inner(
-            td_report.as_ptr() as *const c_void,
-            TD_REPORT_SIZE as u32,
-            quote.as_mut_ptr() as *mut c_void,
-            &mut quote_size as *mut u32,
-        );
-        if result != AttestLibError::Success {
-            return Err(Error::GetQuote);
-        }
-    }
-    quote.truncate(quote_size as usize);
-    Ok(quote)
-}
-
-#[cfg(feature = "AzCVMEmu")]
 pub fn get_quote(td_report: &[u8]) -> Result<Vec<u8>, Error> {
     // Create a GetQuote buffer following TDX GHCI format
-    // This approach works for both AzCVMEmu and normal modes
+    // Header is 20 bytes (version:u64 + status:u64 + in_len:u32 + out_len:u32)
     let tdreport_length = td_report.len();
-    let buffer_size = 32 + tdreport_length + TD_QUOTE_SIZE; // Header + TDReport + space for quote
+    let header_size = core::mem::size_of::<ServtdTdxQuoteHdr>();
+    let buffer_size = header_size + tdreport_length + TD_QUOTE_SIZE; // Header + TDReport + space for quote
     let mut buffer = vec![0u8; buffer_size];
 
-    // Fill GetQuote buffer header
-    // Version (offset 0-7)
-    let version = 1u64.to_le_bytes();
-    buffer[0..8].copy_from_slice(&version);
+    // Fill GetQuote buffer header using the struct
+    let hdr = ServtdTdxQuoteHdr {
+        version: 1,
+        status: 0,
+        in_len: td_report.len() as u32,
+        out_len: TD_QUOTE_SIZE as u32,
+        data: [],
+    };
 
-    // Status will be filled by VMM (offset 8-15)
-    // Initially set to "in flight"
-    let status = 0xFFFFFFFFFFFFFFFFu64.to_le_bytes();
-    buffer[8..16].copy_from_slice(&status);
+    let header_size = core::mem::size_of::<ServtdTdxQuoteHdr>();
+    let hdr_bytes =
+        unsafe { core::slice::from_raw_parts(&hdr as *const _ as *const u8, header_size) };
+    buffer[..header_size].copy_from_slice(hdr_bytes);
 
-    // TDREPORT length (offset 16-23)
-    let tdreport_len_bytes = (tdreport_length as u64).to_le_bytes();
-    buffer[16..24].copy_from_slice(&tdreport_len_bytes);
+    // Copy TDREPORT data immediately after header (offset 20)
+    buffer[header_size..header_size + tdreport_length].copy_from_slice(td_report);
 
-    // Quote buffer length (offset 24-31) - will be updated by VMM
-    let quote_buf_len_bytes = (TD_QUOTE_SIZE as u64).to_le_bytes();
-    buffer[24..32].copy_from_slice(&quote_buf_len_bytes);
-
-    // Copy TDREPORT data (offset 32+)
-    buffer[32..32 + tdreport_length].copy_from_slice(td_report);
-
-    // Call tdvmcall_get_quote with our emulated implementation
-    use tdx_tdcall_emu::tdx::tdvmcall_get_quote;
-
-    if tdvmcall_get_quote(&mut buffer).is_err() {
+    // Call ghci_get_quote
+    let result = ghci_get_quote(buffer.as_mut_ptr() as *mut c_void, buffer.len() as u64);
+    if result != AttestLibError::Success as i32 {
         return Err(Error::GetQuote);
     }
 
-    // Check status for success
-    let status = u64::from_le_bytes([
-        buffer[8], buffer[9], buffer[10], buffer[11], buffer[12], buffer[13], buffer[14],
-        buffer[15],
-    ]);
+    // Read header response
+    let buffer_ptr = buffer.as_ptr() as *const ServtdTdxQuoteHdr;
+    let (status, quote_length) = unsafe {
+        let hdr = &*buffer_ptr;
+        (hdr.status, hdr.out_len as usize)
+    };
 
-    if status != 0 {
+    if status != GET_QUOTE_SUCCESS {
         return Err(Error::GetQuote);
     }
 
-    // Read quote length
-    let quote_length = u64::from_le_bytes([
-        buffer[24], buffer[25], buffer[26], buffer[27], buffer[28], buffer[29], buffer[30],
-        buffer[31],
-    ]) as usize;
+    if quote_length > TD_QUOTE_SIZE {
+        return Err(Error::GetQuote);
+    }
 
     // Extract quote data
-    let quote_start = 32 + tdreport_length;
+    let quote_start = header_size + tdreport_length;
     if buffer.len() < quote_start + quote_length {
         return Err(Error::GetQuote);
     }
@@ -152,7 +145,6 @@ pub fn get_quote(td_report: &[u8]) -> Result<Vec<u8>, Error> {
     let quote = buffer[quote_start..quote_start + quote_length].to_vec();
     Ok(quote)
 }
-
 pub fn verify_quote(quote: &[u8]) -> Result<Vec<u8>, Error> {
     let mut td_report_verify = vec![0u8; TD_REPORT_VERIFY_SIZE];
     let mut report_verify_size = TD_REPORT_VERIFY_SIZE as u32;

--- a/src/attestation/src/lib.rs
+++ b/src/attestation/src/lib.rs
@@ -7,11 +7,19 @@
 
 extern crate alloc;
 
+// Re-export TDX dependencies conditionally to avoid feature gates throughout the code
+#[cfg(not(feature = "AzCVMEmu"))]
+extern crate td_payload;
+#[cfg(not(feature = "AzCVMEmu"))]
+extern crate tdx_tdcall;
+
+#[cfg(feature = "AzCVMEmu")]
+extern crate td_payload_emu as td_payload;
+#[cfg(feature = "AzCVMEmu")]
+extern crate tdx_tdcall_emu as tdx_tdcall;
+
 mod attest;
 mod binding;
-
-// Conditionally compile ghci for non-AzCVMEmu modes
-#[cfg(not(feature = "AzCVMEmu"))]
 mod ghci;
 
 // Conditionally compile collateral for AzCVMEmu mode

--- a/src/devices/vmcall_raw/src/lib.rs
+++ b/src/devices/vmcall_raw/src/lib.rs
@@ -6,19 +6,19 @@
 
 extern crate alloc;
 
-// For AzCVMEmu builds, alias td_payload_emu as td_payload so downstream modules can
-// keep using upstream-style `td_payload::...` imports without changes.
+// Re-export TDX dependencies conditionally to avoid feature gates throughout the code
+#[cfg(not(feature = "AzCVMEmu"))]
+extern crate td_payload;
+#[cfg(not(feature = "AzCVMEmu"))]
+extern crate tdx_tdcall;
+
 #[cfg(feature = "AzCVMEmu")]
 extern crate td_payload_emu as td_payload;
-// No mutual exclusivity needed: real stack is the default, AzCVMEmu swaps to emu stack.
+#[cfg(feature = "AzCVMEmu")]
+extern crate tdx_tdcall_emu as tdx_tdcall;
+
 use core::fmt::{self, Display};
 use rust_std_stub::{error, io};
-
-// Conditional imports based on feature
-#[cfg(feature = "AzCVMEmu")]
-use tdx_tdcall_emu::TdVmcallError;
-
-#[cfg(not(feature = "AzCVMEmu"))]
 use tdx_tdcall::TdVmcallError;
 
 pub mod stream;

--- a/src/devices/vmcall_raw/src/transport/vmcall.rs
+++ b/src/devices/vmcall_raw/src/transport/vmcall.rs
@@ -16,10 +16,7 @@ use lazy_static::lazy_static;
 use spin::Mutex;
 use td_payload::arch::idt::InterruptStack;
 use td_payload::mm::shared::SharedMemory;
-#[cfg(not(feature = "AzCVMEmu"))]
 use tdx_tdcall::tdx;
-#[cfg(feature = "AzCVMEmu")]
-use tdx_tdcall_emu::tdx;
 
 const MAX_VMCALL_RAW_STREAM_MTU: usize = 0x1000 * 160;
 const VMCALL_VECTOR: u8 = 0x52;

--- a/src/migtd/src/config.rs
+++ b/src/migtd/src/config.rs
@@ -4,11 +4,7 @@
 
 use r_efi::efi::Guid;
 use td_layout::build_time::{TD_SHIM_CONFIG_BASE, TD_SHIM_CONFIG_SIZE};
-
-#[cfg(not(feature = "AzCVMEmu"))]
 use td_shim_interface::td_uefi_pi::{fv, pi};
-#[cfg(feature = "AzCVMEmu")]
-use td_shim_interface_emu::td_uefi_pi::{fv, pi};
 
 pub const CONFIG_VOLUME_BASE: usize = TD_SHIM_CONFIG_BASE as usize;
 pub const CONFIG_VOLUME_SIZE: usize = TD_SHIM_CONFIG_SIZE as usize;

--- a/src/migtd/src/event_log.rs
+++ b/src/migtd/src/event_log.rs
@@ -13,16 +13,9 @@ use cc_measurement::{
 use core::mem::size_of;
 use crypto::hash::digest_sha384;
 use spin::Once;
-#[cfg(not(feature = "AzCVMEmu"))]
 use td_payload::acpi::get_acpi_tables;
-#[cfg(feature = "AzCVMEmu")]
-use td_shim_emu::event_log::{get_acpi_tables, MockCcel as Ccel};
-#[cfg(not(feature = "AzCVMEmu"))]
 use td_shim_interface::acpi::Ccel;
-#[cfg(not(feature = "AzCVMEmu"))]
 use tdx_tdcall::tdx;
-#[cfg(feature = "AzCVMEmu")]
-use tdx_tdcall_emu::tdx;
 use zerocopy::{AsBytes, FromBytes};
 
 pub const EV_EVENT_TAG: u32 = 0x00000006;

--- a/src/migtd/src/lib.rs
+++ b/src/migtd/src/lib.rs
@@ -19,6 +19,21 @@ compile_error!("AzCVMEmu only supports vmcall-raw transport. Disable virtio-seri
 #[cfg_attr(feature = "main", macro_use)]
 extern crate alloc;
 
+// Re-export TDX dependencies conditionally to avoid feature gates throughout the code
+#[cfg(not(feature = "AzCVMEmu"))]
+extern crate td_payload;
+#[cfg(not(feature = "AzCVMEmu"))]
+extern crate td_shim_interface;
+#[cfg(not(feature = "AzCVMEmu"))]
+extern crate tdx_tdcall;
+
+#[cfg(feature = "AzCVMEmu")]
+extern crate td_payload_emu as td_payload;
+#[cfg(feature = "AzCVMEmu")]
+extern crate td_shim_interface_emu as td_shim_interface;
+#[cfg(feature = "AzCVMEmu")]
+extern crate tdx_tdcall_emu as tdx_tdcall;
+
 pub mod config;
 pub mod driver;
 pub mod event_log;

--- a/src/migtd/src/mig_policy.rs
+++ b/src/migtd/src/mig_policy.rs
@@ -57,12 +57,6 @@ mod v2 {
 
     use crate::config::get_policy_issuer_chain;
 
-    // Use emulated TDX calls when AzCVMEmu feature is enabled
-    #[cfg(not(feature = "AzCVMEmu"))]
-    use tdx_tdcall;
-    #[cfg(feature = "AzCVMEmu")]
-    use tdx_tdcall_emu as tdx_tdcall;
-
     lazy_static! {
         pub static ref LOCAL_TCB_INFO: Once<PolicyEvaluationInfo> = Once::new();
         pub static ref VERIFIED_POLICY: Once<VerifiedPolicy<'static>> = Once::new();

--- a/src/migtd/src/migration/event.rs
+++ b/src/migtd/src/migration/event.rs
@@ -6,15 +6,8 @@ use alloc::collections::BTreeMap;
 use core::sync::atomic::{AtomicBool, Ordering};
 use lazy_static::lazy_static;
 use spin::Mutex;
-
-#[cfg(not(feature = "AzCVMEmu"))]
 use td_payload::arch::apic::*;
-#[cfg(not(feature = "AzCVMEmu"))]
 use td_payload::arch::idt::{register_interrupt_callback, InterruptCallback, InterruptStack};
-#[cfg(feature = "AzCVMEmu")]
-use td_payload_emu::arch::apic::*;
-#[cfg(feature = "AzCVMEmu")]
-use td_payload_emu::arch::idt::{register_interrupt_callback, InterruptCallback, InterruptStack};
 
 pub const VMCALL_SERVICE_VECTOR: u8 = 0x50;
 pub static VMCALL_SERVICE_FLAG: AtomicBool = AtomicBool::new(false);

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#[cfg(not(feature = "spdm_attestation"))]
-use crate::driver::ticks::with_timeout;
 #[cfg(feature = "vmcall-raw")]
 use crate::migration::event::VMCALL_MIG_REPORTSTATUS_FLAGS;
 use alloc::collections::BTreeSet;
@@ -18,11 +16,7 @@ use core::{future::poll_fn, mem::size_of, task::Poll};
 use event::VMCALL_SERVICE_FLAG;
 use lazy_static::lazy_static;
 use spin::Mutex;
-#[cfg(not(feature = "AzCVMEmu"))]
 use td_payload::mm::shared::SharedMemory;
-#[cfg(feature = "AzCVMEmu")]
-use td_payload_emu::mm::shared::SharedMemory;
-#[cfg(not(feature = "AzCVMEmu"))]
 use tdx_tdcall::{
     td_call,
     tdx::{self, tdcall_servtd_wr},
@@ -30,12 +24,6 @@ use tdx_tdcall::{
 };
 #[cfg(feature = "vmcall-raw")]
 use tdx_tdcall::{tdreport::TdxReport, tdreport::TD_REPORT_ADDITIONAL_DATA_SIZE};
-#[cfg(feature = "AzCVMEmu")]
-use tdx_tdcall_emu::{
-    td_call,
-    tdx::{self, tdcall_servtd_wr},
-    TdcallArgs,
-};
 use zerocopy::AsBytes;
 
 type Result<T> = core::result::Result<T, MigrationResult>;

--- a/src/migtd/src/ratls/server_client.rs
+++ b/src/migtd/src/ratls/server_client.rs
@@ -19,8 +19,6 @@ use super::*;
 #[cfg(feature = "policy_v2")]
 use crate::config::get_policy;
 use crate::event_log::get_event_log;
-#[cfg(feature = "AzCVMEmu")]
-use tdx_tdcall_emu as tdx_tdcall;
 use verify::*;
 
 type Result<T> = core::result::Result<T, RatlsError>;

--- a/src/migtd/src/spdm/mod.rs
+++ b/src/migtd/src/spdm/mod.rs
@@ -31,10 +31,7 @@ pub use spdm_req::spdm_requester;
 pub use spdm_req::spdm_requester_transfer_msk;
 pub use spdm_rsp::spdm_responder;
 pub use spdm_rsp::spdm_responder_transfer_msk;
-#[cfg(not(feature = "AzCVMEmu"))]
 use tdx_tdcall;
-#[cfg(feature = "AzCVMEmu")]
-use tdx_tdcall_emu as tdx_tdcall;
 
 pub use spdm_vdm::*;
 


### PR DESCRIPTION
Apply conditional extern crate re-export pattern to eliminate feature-gated
imports throughout the codebase, reducing diffs from upstream intel/MigTD.

Key changes:
- keeps feature gate for AzCVMEmu mode mostly in MigTDCore lib.rs files
- Add APIC emulation stubs (disable, enable_and_hlt, timer functions) to
  td-payload-emu
- Add ACPI emulation module to td-payload-emu for get_acpi_tables
- Export acpi module from td-shim-interface-emu
- Fix event log emulation with proper CCEL structure
- Add TD_REPORT_ADDITIONAL_DATA_SIZE constant to tdx-tdcall-emu
- Add ghci_get_quote() in attestation/src/ghci.rs for both HW mode and
  AzCVMEmu mode, supporting get_quote() using GHCI interface directly,
  without extra QGS header in the GHCI request