### PR TITLE
build-AzCVMEmu: Add early preflight checks for build dependencies

### DIFF
--- a/sh_script/build_AzCVMEmu_policy_and_test.sh
+++ b/sh_script/build_AzCVMEmu_policy_and_test.sh
@@ -86,6 +86,69 @@ SOURCE_MATERIAL_DIR="$PROJECT_ROOT/config/AzCVMEmu"
 OUTPUT_DIR="$PROJECT_ROOT/config/AzCVMEmu"
 TEMP_DIR=$(mktemp -d)
 TOOLS_DIR="$PROJECT_ROOT/target/release"
+AZCVM_EXTRACT_REPORT_LOCAL_BIN="$PROJECT_ROOT/deps/td-shim-AzCVMEmu/azcvm-extract-report/target/release/azcvm-extract-report"
+AZCVM_EXTRACT_REPORT_WORKSPACE_BIN="$TOOLS_DIR/azcvm-extract-report"
+AZCVM_EXTRACT_REPORT_BIN=""
+
+# Ensure cargo is available (try loading rustup env first).
+if ! command -v cargo >/dev/null 2>&1; then
+    if [ -f "$HOME/.cargo/env" ]; then
+        # shellcheck source=/dev/null
+        . "$HOME/.cargo/env"
+    fi
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo -e "${RED}Error: cargo not found in PATH.${NC}" >&2
+    echo -e "${YELLOW}Install Rust toolchain and reload your shell:${NC}" >&2
+    echo "  sudo apt install -y rustup" >&2
+    echo "  rustup default stable" >&2
+    echo "  source \"\$HOME/.cargo/env\"" >&2
+    echo "  ./sh_script/build_AzCVMEmu_policy_and_test.sh --mock-report" >&2
+    exit 127
+fi
+
+if ! command -v pkg-config >/dev/null 2>&1; then
+    echo -e "${RED}Error: pkg-config not found in PATH.${NC}" >&2
+    echo -e "${YELLOW}Install required build dependencies:${NC}" >&2
+    echo "  sudo apt install -y pkg-config libtss2-dev" >&2
+    exit 127
+fi
+
+if ! pkg-config --exists tss2-sys; then
+    echo -e "${RED}Error: TPM2 system library 'tss2-sys' not found.${NC}" >&2
+    echo -e "${YELLOW}Install required TPM2 development package:${NC}" >&2
+    echo "  sudo apt install -y libtss2-dev" >&2
+    exit 127
+fi
+
+if ! command -v nasm >/dev/null 2>&1; then
+    echo -e "${RED}Error: nasm not found in PATH.${NC}" >&2
+    echo -e "${YELLOW}Install required assembler dependency:${NC}" >&2
+    echo "  sudo apt install -y nasm" >&2
+    exit 127
+fi
+
+if ! command -v unzip >/dev/null 2>&1; then
+    echo -e "${RED}Error: unzip not found in PATH.${NC}" >&2
+    echo -e "${YELLOW}Install required archive extraction tool:${NC}" >&2
+    echo "  sudo apt install -y unzip" >&2
+    exit 127
+fi
+
+if ! command -v autoreconf >/dev/null 2>&1; then
+    echo -e "${RED}Error: autoreconf not found in PATH.${NC}" >&2
+    echo -e "${YELLOW}Install required autotools dependencies:${NC}" >&2
+    echo "  sudo apt install -y autoconf automake libtool" >&2
+    exit 127
+fi
+
+if ! command -v ocamlbuild >/dev/null 2>&1; then
+    echo -e "${RED}Error: ocamlbuild not found in PATH.${NC}" >&2
+    echo -e "${YELLOW}Install required OCaml build tools:${NC}" >&2
+    echo "  sudo apt install -y ocaml ocamlbuild" >&2
+    exit 127
+fi
 
 # Input Files
 POLICY_DATA_RAW="$SOURCE_MATERIAL_DIR/policy_v2_raw.json"
@@ -376,21 +439,40 @@ echo -e "${BLUE}=== Step 1: Building Tools ===${NC}"
 cd "$PROJECT_ROOT"
 
 echo "Building azcvm-extract-report (from deps/td-shim-AzCVMEmu)..."
-(cd deps/td-shim-AzCVMEmu/azcvm-extract-report && cargo build --release) 2>&1 | grep -E "(Compiling|Finished|error)" || true
+if ! (cd deps/td-shim-AzCVMEmu/azcvm-extract-report && cargo build --release); then
+    echo -e "${RED}Error: Failed to build azcvm-extract-report${NC}" >&2
+    exit 1
+fi
 
 echo "Building json-signer..."
-cargo build --release -p json-signer 2>&1 | grep -E "(Compiling|Finished|error)" || true
+if ! cargo build --release -p json-signer; then
+    echo -e "${RED}Error: Failed to build json-signer${NC}" >&2
+    exit 1
+fi
 
 echo "Building servtd-collateral-generator..."
-cargo build --release -p servtd-collateral-generator 2>&1 | grep -E "(Compiling|Finished|error)" || true
+if ! cargo build --release -p servtd-collateral-generator; then
+    echo -e "${RED}Error: Failed to build servtd-collateral-generator${NC}" >&2
+    exit 1
+fi
 
 echo "Building migtd-policy-generator..."
-cargo build --release -p migtd-policy-generator 2>&1 | grep -E "(Compiling|Finished|error)" || true
+if ! cargo build --release -p migtd-policy-generator; then
+    echo -e "${RED}Error: Failed to build migtd-policy-generator${NC}" >&2
+    exit 1
+fi
 
 # Verify tools exist
-# Note: azcvm-extract-report is in a different location
-if [ ! -f "$PROJECT_ROOT/deps/td-shim-AzCVMEmu/azcvm-extract-report/target/release/azcvm-extract-report" ]; then
-    echo -e "${RED}Error: Tool 'azcvm-extract-report' not found${NC}" >&2
+# azcvm-extract-report may be emitted either to the local crate target/ or the
+# workspace target/ when CARGO_TARGET_DIR is set.
+if [ -f "$AZCVM_EXTRACT_REPORT_LOCAL_BIN" ]; then
+    AZCVM_EXTRACT_REPORT_BIN="$AZCVM_EXTRACT_REPORT_LOCAL_BIN"
+elif [ -f "$AZCVM_EXTRACT_REPORT_WORKSPACE_BIN" ]; then
+    AZCVM_EXTRACT_REPORT_BIN="$AZCVM_EXTRACT_REPORT_WORKSPACE_BIN"
+else
+    echo -e "${RED}Error: Tool 'azcvm-extract-report' not found at either:${NC}" >&2
+    echo -e "${RED}  - $AZCVM_EXTRACT_REPORT_LOCAL_BIN${NC}" >&2
+    echo -e "${RED}  - $AZCVM_EXTRACT_REPORT_WORKSPACE_BIN${NC}" >&2
     exit 1
 fi
 
@@ -424,7 +506,7 @@ if [ "$USE_MOCK_REPORT" = true ]; then
         export MOCK_QUOTE_FILE
     fi
 
-    "$PROJECT_ROOT/deps/td-shim-AzCVMEmu/azcvm-extract-report/target/release/azcvm-extract-report" \
+    "$AZCVM_EXTRACT_REPORT_BIN" \
         --mock-report \
         --output-json "migtd_report_data.json"
 
@@ -436,7 +518,7 @@ if [ "$USE_MOCK_REPORT" = true ]; then
 else
     # Use sudo to access vTPM device (requires /dev/tpmrm0 access)
     echo "Note: Using sudo to access vTPM device..."
-    sudo "$PROJECT_ROOT/deps/td-shim-AzCVMEmu/azcvm-extract-report/target/release/azcvm-extract-report"
+    sudo "$AZCVM_EXTRACT_REPORT_BIN"
 
     # Report extractor creates migtd_report_data.json in current directory
     if [ ! -f "migtd_report_data.json" ]; then

--- a/sh_script/build_AzCVMEmu_policy_and_test.sh
+++ b/sh_script/build_AzCVMEmu_policy_and_test.sh
@@ -80,6 +80,49 @@ NC='\033[0m' # No Color
 echo -e "${BLUE}=== MigTD Custom Policy Builder ===${NC}"
 echo
 
+print_error() {
+    printf '%b\n' "${RED}Error: $1${NC}" >&2
+}
+
+print_hint_header() {
+    printf '%b\n' "${YELLOW}$1${NC}" >&2
+}
+
+print_hint_lines() {
+    local hint
+    for hint in "$@"; do
+        printf '  %s\n' "$hint" >&2
+    done
+}
+
+require_cmd() {
+    local cmd="$1"
+    local error_message="$2"
+    local hint_header="$3"
+    shift 3
+
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        print_error "$error_message"
+        print_hint_header "$hint_header"
+        print_hint_lines "$@"
+        exit 127
+    fi
+}
+
+require_pkg_config_module() {
+    local module="$1"
+    local error_message="$2"
+    local hint_header="$3"
+    shift 3
+
+    if ! pkg-config --exists "$module" >/dev/null 2>&1; then
+        print_error "$error_message"
+        print_hint_header "$hint_header"
+        print_hint_lines "$@"
+        exit 127
+    fi
+}
+
 # Default paths
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SOURCE_MATERIAL_DIR="$PROJECT_ROOT/config/AzCVMEmu"
@@ -98,57 +141,51 @@ if ! command -v cargo >/dev/null 2>&1; then
     fi
 fi
 
-if ! command -v cargo >/dev/null 2>&1; then
-    echo -e "${RED}Error: cargo not found in PATH.${NC}" >&2
-    echo -e "${YELLOW}Install Rust toolchain and reload your shell:${NC}" >&2
-    echo "  sudo apt install -y rustup" >&2
-    echo "  rustup default stable" >&2
-    echo "  source \"\$HOME/.cargo/env\"" >&2
-    echo "  ./sh_script/build_AzCVMEmu_policy_and_test.sh --mock-report" >&2
-    exit 127
-fi
+require_cmd \
+    cargo \
+    "cargo not found in PATH." \
+    "Install Rust toolchain and reload your shell (platform-specific):" \
+    "Cross-platform (recommended): https://rustup.rs" \
+    "Debian/Ubuntu: sudo apt install -y rustup" \
+    "rustup default stable" \
+    "source \"\$HOME/.cargo/env\"" \
+    "./sh_script/build_AzCVMEmu_policy_and_test.sh --mock-report"
 
-if ! command -v pkg-config >/dev/null 2>&1; then
-    echo -e "${RED}Error: pkg-config not found in PATH.${NC}" >&2
-    echo -e "${YELLOW}Install required build dependencies:${NC}" >&2
-    echo "  sudo apt install -y pkg-config libtss2-dev" >&2
-    exit 127
-fi
+require_cmd \
+    pkg-config \
+    "pkg-config not found in PATH." \
+    "Install required build dependencies (platform-specific):" \
+    "Debian/Ubuntu: sudo apt install -y pkg-config libtss2-dev"
 
-if ! pkg-config --exists tss2-sys; then
-    echo -e "${RED}Error: TPM2 system library 'tss2-sys' not found.${NC}" >&2
-    echo -e "${YELLOW}Install required TPM2 development package:${NC}" >&2
-    echo "  sudo apt install -y libtss2-dev" >&2
-    exit 127
-fi
+require_pkg_config_module \
+    tss2-sys \
+    "TPM2 system library 'tss2-sys' not found." \
+    "Install required TPM2 development package (platform-specific):" \
+    "Debian/Ubuntu: sudo apt install -y libtss2-dev"
 
-if ! command -v nasm >/dev/null 2>&1; then
-    echo -e "${RED}Error: nasm not found in PATH.${NC}" >&2
-    echo -e "${YELLOW}Install required assembler dependency:${NC}" >&2
-    echo "  sudo apt install -y nasm" >&2
-    exit 127
-fi
+require_cmd \
+    nasm \
+    "nasm not found in PATH." \
+    "Install required assembler dependency (platform-specific):" \
+    "Debian/Ubuntu: sudo apt install -y nasm"
 
-if ! command -v unzip >/dev/null 2>&1; then
-    echo -e "${RED}Error: unzip not found in PATH.${NC}" >&2
-    echo -e "${YELLOW}Install required archive extraction tool:${NC}" >&2
-    echo "  sudo apt install -y unzip" >&2
-    exit 127
-fi
+require_cmd \
+    unzip \
+    "unzip not found in PATH." \
+    "Install required archive extraction tool (platform-specific):" \
+    "Debian/Ubuntu: sudo apt install -y unzip"
 
-if ! command -v autoreconf >/dev/null 2>&1; then
-    echo -e "${RED}Error: autoreconf not found in PATH.${NC}" >&2
-    echo -e "${YELLOW}Install required autotools dependencies:${NC}" >&2
-    echo "  sudo apt install -y autoconf automake libtool" >&2
-    exit 127
-fi
+require_cmd \
+    autoreconf \
+    "autoreconf not found in PATH." \
+    "Install required autotools dependencies (platform-specific):" \
+    "Debian/Ubuntu: sudo apt install -y autoconf automake libtool"
 
-if ! command -v ocamlbuild >/dev/null 2>&1; then
-    echo -e "${RED}Error: ocamlbuild not found in PATH.${NC}" >&2
-    echo -e "${YELLOW}Install required OCaml build tools:${NC}" >&2
-    echo "  sudo apt install -y ocaml ocamlbuild" >&2
-    exit 127
-fi
+require_cmd \
+    ocamlbuild \
+    "ocamlbuild not found in PATH." \
+    "Install required OCaml build tools (platform-specific):" \
+    "Debian/Ubuntu: sudo apt install -y ocaml ocamlbuild"
 
 # Input Files
 POLICY_DATA_RAW="$SOURCE_MATERIAL_DIR/policy_v2_raw.json"


### PR DESCRIPTION
- Add checks for cargo, pkg-config, tss2-sys, nasm, unzip, autoreconf, ocamlbuild
- Print actionable install commands when tools are missing
- Fix azcvm-extract-report binary path resolution (local vs workspace target)
- Replace build output filtering with explicit error reporting
- Fail fast with clear messages instead of cryptic tool-not-found errors 
- Fixes issues where build would fail partway through with generic errors.
@haitaohuang
@cwshugg