### PR TITLE
revert: undo poll_fn error handling changes from 0200bd1 and b943908

### DIFF
--- a/src/devices/vmcall_raw/src/transport/vmcall.rs
+++ b/src/devices/vmcall_raw/src/transport/vmcall.rs
@@ -80,53 +80,41 @@ pub fn vmcall_raw_transport_can_recv() -> Result<bool, ()> {
 /// Poll the VMM completion status for a pending VMCALL operation.
 ///
 /// Shared logic for both send and receive: checks the interrupt flag,
-/// parses data_status from the shared buffer header, and consumes the
-/// flag only after the VMM has written a final (non-zero) status.
+/// parses data_status from the shared buffer header, and immediately
+/// consumes the flag so work only happens on a real interrupt.
 ///
 /// Returns `Poll::Pending` if the operation is still in flight,
 /// `Poll::Ready(Ok((payload, data_length)))` on success, or
-/// `Poll::Ready(Err(...))` on VMM error or missing context.
+/// `Poll::Ready(Err(...))` on VMM cancellation or missing context.
 fn poll_vmcall_completion<'a>(
     mig_request_id: u64,
     data_buffer: &'a mut [u8],
 ) -> Poll<Result<(&'a mut [u8], u32), VmcallRawError>> {
     if let Some(flag) = VMCALL_MIG_CONTEXT_FLAGS.lock().get(&mig_request_id) {
-        if !flag.load(Ordering::SeqCst) {
+        if flag.load(Ordering::SeqCst) {
+            flag.store(false, Ordering::SeqCst);
+        } else {
             return Poll::Pending;
         }
     } else {
-        return Poll::Ready(Err(VmcallRawError::Illegal));
+        let _ = Poll::Ready(Err::<(&mut [u8], u32), _>(VmcallRawError::Illegal));
     }
 
     let (payload, data_status, data_length) = process_buffer(data_buffer);
-
-    if data_status == 0 {
-        // VMM hasn't written the response yet
-        return Poll::Pending;
-    }
-
-    // Only consume the flag after VMM has written a final status
-    if let Some(flag) = VMCALL_MIG_CONTEXT_FLAGS.lock().get(&mig_request_id) {
-        flag.store(false, Ordering::SeqCst);
-    }
-
     let status_bytes = data_status.to_le_bytes();
-    if status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
-        // byte[0]=0x02 (not completed), byte[1]=0x03 (VMM cancel)
-        if status_bytes[0] == 0x02 && status_bytes[1] == 0x03 {
-            log::warn!(
-                "VMM canceled migration session (migration_request_id={}, data_status=0x{:x})\n",
-                mig_request_id,
-                data_status
-            );
-            return Poll::Ready(Err(VmcallRawError::VmmCanceled));
-        }
-        log::error!(
-            "vmcall failed (migration_request_id={}, data_status=0x{:x})\n",
+
+    // byte[0]=0x02 (not completed), byte[1]=0x03 (VMM cancel)
+    if status_bytes[0] == 0x02 && status_bytes[1] == 0x03 {
+        log::warn!(
+            "VMM canceled migration session (migration_request_id={}, data_status=0x{:x})\n",
             mig_request_id,
             data_status
         );
-        return Poll::Ready(Err(VmcallRawError::TdVmcallErr));
+        return Poll::Ready(Err(VmcallRawError::VmmCanceled));
+    }
+
+    if status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
+        return Poll::Pending;
     }
 
     Poll::Ready(Ok((payload, data_length)))

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -484,7 +484,9 @@ pub async fn wait_for_request() -> Result<WaitForRequestResponse> {
 
     let mut pending_error_report: Option<(u64, MigrationResult)> = None;
     let result = poll_fn(|_cx| {
-        if !VMCALL_SERVICE_FLAG.load(Ordering::SeqCst) {
+        if VMCALL_SERVICE_FLAG.load(Ordering::SeqCst) {
+            VMCALL_SERVICE_FLAG.store(false, Ordering::SeqCst);
+        } else {
             return Poll::Pending;
         }
 
@@ -495,14 +497,7 @@ pub async fn wait_for_request() -> Result<WaitForRequestResponse> {
             return Poll::Ready(Err(MigrationResult::OutOfResource));
         };
 
-        let result = parse_request(data_buffer, reqbufferhdrlen, &mut pending_error_report);
-
-        // Only consume the flag after data is confirmed ready (not Pending)
-        if !matches!(result, Poll::Pending) {
-            VMCALL_SERVICE_FLAG.store(false, Ordering::SeqCst);
-        }
-
-        result
+        parse_request(data_buffer, reqbufferhdrlen, &mut pending_error_report)
     })
     .await;
 
@@ -549,7 +544,9 @@ pub async fn wait_for_request() -> Result<MigrationInformation> {
         tdx::tdvmcall_service(cmd_mem.as_bytes(), rsp_mem.as_mut_bytes(), 0, 0)?;
 
         #[cfg(feature = "vmcall-interrupt")]
-        if !VMCALL_SERVICE_FLAG.load(Ordering::SeqCst) {
+        if VMCALL_SERVICE_FLAG.load(Ordering::SeqCst) {
+            VMCALL_SERVICE_FLAG.store(false, Ordering::SeqCst);
+        } else {
             return Poll::Pending;
         }
 
@@ -566,8 +563,6 @@ pub async fn wait_for_request() -> Result<MigrationInformation> {
                 "wait_for_request: GUID mismatch in response rsp.read_guid() = {:?}\n",
                 rsp.read_guid()
             );
-            #[cfg(feature = "vmcall-interrupt")]
-            VMCALL_SERVICE_FLAG.store(false, Ordering::SeqCst);
             return Poll::Ready(Err(MigrationResult::InvalidParameter));
         }
         let wfr = rsp
@@ -578,8 +573,6 @@ pub async fn wait_for_request() -> Result<MigrationInformation> {
                 "wait_for_request: command mismatch in response wfr.command = {:?}\n",
                 wfr.command
             );
-            #[cfg(feature = "vmcall-interrupt")]
-            VMCALL_SERVICE_FLAG.store(false, Ordering::SeqCst);
             return Poll::Ready(Err(MigrationResult::InvalidParameter));
         }
         if wfr.operation == 1 {
@@ -591,16 +584,12 @@ pub async fn wait_for_request() -> Result<MigrationInformation> {
             if REQUESTS.lock().contains(&request_id) {
                 Poll::Pending
             } else {
-                #[cfg(feature = "vmcall-interrupt")]
-                VMCALL_SERVICE_FLAG.store(false, Ordering::SeqCst);
                 REQUESTS.lock().insert(request_id);
                 Poll::Ready(Ok(mig_info))
             }
         } else if wfr.operation == 0 {
             Poll::Pending
         } else {
-            #[cfg(feature = "vmcall-interrupt")]
-            VMCALL_SERVICE_FLAG.store(false, Ordering::SeqCst);
             Poll::Ready(Err(MigrationResult::InvalidParameter))
         }
     })
@@ -755,19 +744,10 @@ pub async fn report_status(status: u8, request_id: u64, data: &Vec<u8>) -> Resul
 
     poll_fn(|_cx| -> Poll<Result<()>> {
         reqbufferhdr = process_buffer(data_buffer);
-        let data_status = reqbufferhdr.datastatus;
-
-        if data_status == 0 {
-            // VMM hasn't written the response yet
+        let data_status_bytes = &reqbufferhdr.datastatus.to_le_bytes();
+        if data_status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
+            log::info!(migration_request_id = request_id; "report_status: Pending confirmation\n");
             return Poll::Pending;
-        }
-
-        if data_status.to_le_bytes()[0] != TDX_VMCALL_VMM_SUCCESS {
-            log::error!(migration_request_id = request_id;
-                "report_status: VMM returned error, data_status=0x{:x}\n",
-                data_status
-            );
-            return Poll::Ready(Err(MigrationResult::VmmInternalError));
         }
 
         Poll::Ready(Ok(()))


### PR DESCRIPTION
Revert the poll_fn flag and error handling changes introduced in:
- 0200bd1 session: fix poll_fn flag and error handling
- b943908 vmcall_raw: fix poll_fn error handling in send and receive

Restore the original pattern: immediately consume the interrupt flag so poll_fn only does work when a real interrupt sets the flag to true. VMM cancellation handling (88f0297) is preserved.