### PR TITLE
feat(logging): truncate long log messages

### DIFF
--- a/src/migtd/src/migration/logging.rs
+++ b/src/migtd/src/migration/logging.rs
@@ -584,6 +584,61 @@ impl VisitSource<'_> for RequestIdVisitor {
 /// Custom logger that routes log messages to structured logging
 pub struct VmmLoggerBackend;
 
+/// Maximum log message size in bytes before truncation is applied.
+/// Messages longer than this are replaced with a summary showing the first
+/// `LOG_TRUNCATE_HEAD` bytes, the last `LOG_TRUNCATE_TAIL` bytes, and the
+/// number of bytes that were dropped.
+const LOG_TRUNCATE_THRESHOLD: usize = 128;
+const LOG_TRUNCATE_HEAD: usize = 64;
+const LOG_TRUNCATE_TAIL: usize = 16;
+
+/// Truncate `msg` if it exceeds `LOG_TRUNCATE_THRESHOLD`.
+/// Returns the original message unchanged when it fits, or a replacement of
+/// the form: `[first ~64 bytes]... [last ~16 bytes], log truncated number of bytes: N`
+///
+/// Head and tail boundaries are adjusted to the nearest UTF-8 character
+/// boundary so that multi-byte characters are never split.
+fn maybe_truncate(msg: Vec<u8>) -> Vec<u8> {
+    if msg.len() <= LOG_TRUNCATE_THRESHOLD {
+        return msg;
+    }
+    // Strip all trailing newlines so they don't appear between tail and the notice.
+    let mut data_end = msg.len();
+    while data_end > 0 && msg[data_end - 1] == b'\n' {
+        data_end -= 1;
+    }
+    let data = &msg[..data_end];
+    let total = data.len();
+
+    // Find UTF-8-safe cut points. Input originates from format!() so it is
+    // valid UTF-8, but fall back to raw byte offsets if it somehow isn't.
+    let (head_end, tail_start) = if let Ok(s) = core::str::from_utf8(data) {
+        // floor_char_boundary: largest boundary <= LOG_TRUNCATE_HEAD
+        let mut h = LOG_TRUNCATE_HEAD.min(s.len());
+        while h > 0 && !s.is_char_boundary(h) {
+            h -= 1;
+        }
+        // ceil_char_boundary: smallest boundary >= total - LOG_TRUNCATE_TAIL
+        let mut t = total.saturating_sub(LOG_TRUNCATE_TAIL);
+        while t < s.len() && !s.is_char_boundary(t) {
+            t += 1;
+        }
+        (h, t)
+    } else {
+        (LOG_TRUNCATE_HEAD, total.saturating_sub(LOG_TRUNCATE_TAIL))
+    };
+
+    let head = &data[..head_end];
+    let tail = &data[tail_start..];
+    let truncated = tail_start - head_end;
+    let mut out = Vec::with_capacity(head.len() + tail.len() + 64);
+    out.extend_from_slice(head);
+    out.extend_from_slice(b"... ");
+    out.extend_from_slice(tail);
+    out.extend_from_slice(format!(", log truncated number of bytes: {}\n", truncated).as_bytes());
+    out
+}
+
 impl log::Log for VmmLoggerBackend {
     fn enabled(&self, metadata: &Metadata) -> bool {
         let log_max_level: LevelFilter;
@@ -612,6 +667,7 @@ impl log::Log for VmmLoggerBackend {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             let msg = format!("{}\n", record.args());
+            let msg = maybe_truncate(msg.into_bytes());
 
             let mut visitor = RequestIdVisitor {
                 mig_request_id: None,
@@ -622,24 +678,21 @@ impl log::Log for VmmLoggerBackend {
                 .mig_request_id
                 .unwrap_or(MIGRATION_REQUEST_ID_SENTINEL);
 
-            entrylog(&msg.into_bytes(), record.level(), mig_request_id);
+            entrylog(&msg, record.level(), mig_request_id);
 
             // Also output to debug console for development (skip in test mode to avoid issues)
             #[cfg(all(not(test), debug_assertions))]
             {
+                let msg_str = alloc::string::String::from_utf8_lossy(&msg);
                 if mig_request_id != MIGRATION_REQUEST_ID_SENTINEL {
                     td_logger::dbg_write_string(&format!(
-                        "{} - [req_id: {}] {}\n",
+                        "{} - [req_id: {}] {}",
                         record.level(),
                         mig_request_id,
-                        record.args()
+                        msg_str
                     ));
                 } else {
-                    td_logger::dbg_write_string(&format!(
-                        "{} - {}\n",
-                        record.level(),
-                        record.args()
-                    ));
+                    td_logger::dbg_write_string(&format!("{} - {}", record.level(), msg_str));
                 }
             }
         }
@@ -1586,5 +1639,83 @@ mod test {
         unsafe {
             let _ = Box::from_raw(data_buffer_ptr as *mut [u8; PAGE_SIZE]);
         }
+    }
+
+    #[test]
+    fn test_maybe_truncate_short_message() {
+        let msg = b"short message\n".to_vec();
+        let result = maybe_truncate(msg.clone());
+        assert_eq!(result, msg);
+    }
+
+    #[test]
+    fn test_maybe_truncate_at_threshold() {
+        let msg = vec![b'A'; LOG_TRUNCATE_THRESHOLD];
+        let result = maybe_truncate(msg.clone());
+        assert_eq!(
+            result, msg,
+            "message exactly at threshold should not be truncated"
+        );
+    }
+
+    #[test]
+    fn test_maybe_truncate_over_threshold() {
+        // Simulate a real log message: content + trailing newline
+        let content_len = LOG_TRUNCATE_THRESHOLD + 100;
+        let mut msg: Vec<u8> = (0..content_len).map(|i| b'A' + (i % 26) as u8).collect();
+        msg.push(b'\n');
+        let result = maybe_truncate(msg.clone());
+
+        assert_ne!(result, msg);
+        // Starts with first LOG_TRUNCATE_HEAD bytes of content
+        assert_eq!(&result[..LOG_TRUNCATE_HEAD], &msg[..LOG_TRUNCATE_HEAD]);
+        // Contains "... " separator
+        assert_eq!(&result[LOG_TRUNCATE_HEAD..LOG_TRUNCATE_HEAD + 4], b"... ");
+        // Contains last LOG_TRUNCATE_TAIL bytes of content (newline stripped)
+        assert_eq!(
+            &result[LOG_TRUNCATE_HEAD + 4..LOG_TRUNCATE_HEAD + 4 + LOG_TRUNCATE_TAIL],
+            &msg[content_len - LOG_TRUNCATE_TAIL..content_len]
+        );
+        // Ends with the truncation notice (single newline, no double)
+        let truncated = content_len - LOG_TRUNCATE_HEAD - LOG_TRUNCATE_TAIL;
+        let trailer = format!(", log truncated number of bytes: {}\n", truncated);
+        assert!(
+            result.ends_with(trailer.as_bytes()),
+            "expected trailer: {trailer}, got: {}",
+            String::from_utf8_lossy(&result)
+        );
+        // No double newline anywhere
+        assert!(
+            !result.windows(2).any(|w| w == b"\n\n"),
+            "should not contain double newline: {}",
+            String::from_utf8_lossy(&result)
+        );
+    }
+
+    #[test]
+    fn test_maybe_truncate_multibyte_utf8() {
+        // Build a string where the LOG_TRUNCATE_HEAD and LOG_TRUNCATE_TAIL
+        // byte offsets fall in the middle of multi-byte characters.
+        // 'é' is 2 bytes (0xC3 0xA9); fill with 'é' so every odd offset
+        // is mid-character.
+        let c = 'é'; // 2 bytes each
+        let char_count = (LOG_TRUNCATE_THRESHOLD / 2) + 60; // well over threshold in bytes
+        let mut s: String = core::iter::repeat(c).take(char_count).collect();
+        s.push('\n');
+        let msg = s.into_bytes();
+        assert!(msg.len() > LOG_TRUNCATE_THRESHOLD);
+
+        let result = maybe_truncate(msg);
+        // The result must be valid UTF-8 (no split characters)
+        let result_str = core::str::from_utf8(&result)
+            .expect("truncated output must be valid UTF-8");
+        assert!(
+            result_str.contains("... "),
+            "should contain separator: {result_str}"
+        );
+        assert!(
+            result_str.contains("log truncated number of bytes:"),
+            "should contain truncation notice: {result_str}"
+        );
     }
 }


### PR DESCRIPTION
Messages exceeding 128 bytes are truncated, showing the first 64 and last 16 bytes with a byte-count notice. Applies to both logentry and serial/debug console output.

This only affects debug level messages where lengthy info like quote dumped. The lengthy debug message has been hitting the timeout limit set by Azure OS for Send/Receive transactions